### PR TITLE
Add 4 missing quotes

### DIFF
--- a/docs/manual/en/introduction/Creating-a-scene.html
+++ b/docs/manual/en/introduction/Creating-a-scene.html
@@ -20,7 +20,7 @@
 		&lt;!DOCTYPE html&gt;
 		&lt;html&gt;
 			&lt;head&gt;
-				&lt;meta charset=utf-8&gt;
+				&lt;meta charset="utf-8"&gt;
 				&lt;title&gt;My first three.js app&lt;/title&gt;
 				&lt;style&gt;
 					body { margin: 0; }

--- a/docs/manual/zh/introduction/Creating-a-scene.html
+++ b/docs/manual/zh/introduction/Creating-a-scene.html
@@ -20,7 +20,7 @@
 		&lt;!DOCTYPE html&gt;
 		&lt;html&gt;
 			&lt;head&gt;
-				&lt;meta charset=utf-8&gt;
+				&lt;meta charset="utf-8"&gt;
 				&lt;title&gt;My first three.js app&lt;/title&gt;
 				&lt;style&gt;
 					body { margin: 0; }


### PR DESCRIPTION
When copy-pasting the HTML provided on the Creating a scene tutorial, glitch.com complains about it:

![image](https://user-images.githubusercontent.com/35064754/62825187-10aa3200-bba8-11e9-81e1-b8bc4b3909dd.png)

So I think this is a mistake and fixed it.